### PR TITLE
Fixed multiexp with thread limit

### DIFF
--- a/c/curve.hpp
+++ b/c/curve.hpp
@@ -117,7 +117,7 @@ public:
 
     void multiMulByScalar(Point &r, PointAffine *bases, uint8_t* scalars, unsigned int scalarSize, unsigned int n, unsigned int nThreads=0) {
         ParallelMultiexp<Curve<BaseField>> pm(*this);
-        pm.multiexp(r, bases, scalars, scalarSize, n);
+        pm.multiexp(r, bases, scalars, scalarSize, n, nThreads);
     }
 
 #ifdef COUNT_OPS

--- a/c/misc.hpp
+++ b/c/misc.hpp
@@ -1,8 +1,30 @@
 #ifndef MISC_H
 #define MISC_H
 
+#include <omp.h>
 #include <cstdint>
 
 uint32_t log2 (uint32_t value);
+
+/**
+ * This object is used to temporarily change the max number of omp threads.
+ * When the object is destructed, the max threads is set to it's original value.
+ */
+class ThreadLimit {
+public:
+    ThreadLimit(uint32_t maxThreads):
+        prev_max_threads(omp_get_max_threads())
+    {
+        omp_set_num_threads(maxThreads);
+    }
+
+    ~ThreadLimit() noexcept
+    {
+        omp_set_num_threads(prev_max_threads);
+    }
+
+private:
+    uint32_t prev_max_threads;
+};
 
 #endif // MISC_H

--- a/c/multiexp.cpp
+++ b/c/multiexp.cpp
@@ -98,11 +98,12 @@ void ParallelMultiexp<Curve>::reduce(typename Curve::Point &res, uint32_t nBits)
 template <typename Curve>
 void ParallelMultiexp<Curve>::multiexp(typename Curve::Point &r, typename Curve::PointAffine *_bases, uint8_t* _scalars, uint32_t _scalarSize, uint32_t _n, uint32_t _nThreads) {
     nThreads = _nThreads==0 ? omp_get_max_threads() : _nThreads;
-//    nThreads = 1;
     bases = _bases;
     scalars = _scalars;
     scalarSize = _scalarSize;
     n = _n;
+
+    ThreadLimit threadLimit (nThreads);
 
     if (n==0) {
         g.copy(r, g.zero());


### PR DESCRIPTION
curve's multiMulByScalar never supported a thread limit (the nThreads arg was unused),
and multiexp's thread limit was broken in the switch to omp.