### PR TITLE
Add radix argument to fromString() method and use const in constant arguments

### DIFF
--- a/c/alt_bn128.hpp
+++ b/c/alt_bn128.hpp
@@ -1,5 +1,8 @@
-#include "../build/fq.hpp"
-#include "../build/fr.hpp"
+#ifndef ALT_BN128_HPP
+#define ALT_BN128_HPP
+
+#include "fq.hpp"
+#include "fr.hpp"
 #include "f2field.hpp"
 #include "curve.hpp"
 #include <string>
@@ -60,3 +63,4 @@ namespace AltBn128 {
 
 }  // Namespace
 
+#endif

--- a/src/fr.cpp.ejs
+++ b/src/fr.cpp.ejs
@@ -179,7 +179,7 @@ Raw<%=name%>::~Raw<%=name%>() {
 
 void Raw<%=name%>::fromString(Element &r, const std::string &s, uint32_t radix) {
     mpz_t mr;
-    mpz_init_set_str(mr, s.c_str(), 10);
+    mpz_init_set_str(mr, s.c_str(), radix);
     mpz_fdiv_r(mr, mr, q);
     for (int i=0; i<<%=name%>_N64; i++) r.v[i] = 0;
     mpz_export((void *)(r.v), NULL, -1, 8, -1, 0, mr);

--- a/src/fr.cpp.ejs
+++ b/src/fr.cpp.ejs
@@ -177,7 +177,7 @@ Raw<%=name%>::Raw<%=name%>() {
 Raw<%=name%>::~Raw<%=name%>() {
 }
 
-void Raw<%=name%>::fromString(Element &r, std::string s) {
+void Raw<%=name%>::fromString(Element &r, const std::string &s, uint32_t radix) {
     mpz_t mr;
     mpz_init_set_str(mr, s.c_str(), 10);
     mpz_fdiv_r(mr, mr, q);
@@ -199,7 +199,7 @@ void Raw<%=name%>::fromUI(Element &r, unsigned long int v) {
 
 
 
-std::string Raw<%=name%>::toString(Element &a, uint32_t radix) {
+std::string Raw<%=name%>::toString(const Element &a, uint32_t radix) {
     Element tmp;
     mpz_t r;
     <%=name%>_rawFromMontgomery(tmp.v, a.v);
@@ -212,7 +212,7 @@ std::string Raw<%=name%>::toString(Element &a, uint32_t radix) {
     return resS;
 }
 
-void Raw<%=name%>::inv(Element &r, Element &a) {
+void Raw<%=name%>::inv(Element &r, const Element &a) {
     mpz_t mr;
     mpz_init(mr);
     mpz_import(mr, <%=name%>_N64, -1, 8, -1, 0, (const void *)(a.v));
@@ -226,14 +226,14 @@ void Raw<%=name%>::inv(Element &r, Element &a) {
     mpz_clear(mr);
 }
 
-void Raw<%=name%>::div(Element &r, Element &a, Element &b) {
+void Raw<%=name%>::div(Element &r, const Element &a, const Element &b) {
     Element tmp;
     inv(tmp, b);
     mul(r, a, tmp);
 }
 
 #define BIT_IS_SET(s, p) (s[p>>3] & (1 << (p & 0x7)))
-void Raw<%=name%>::exp(Element &r, Element &base, uint8_t* scalar, unsigned int scalarSize) {
+void Raw<%=name%>::exp(Element &r, const Element &base, uint8_t* scalar, unsigned int scalarSize) {
     bool oneFound = false;
     Element copyBase;
     copy(copyBase, base);
@@ -254,13 +254,13 @@ void Raw<%=name%>::exp(Element &r, Element &base, uint8_t* scalar, unsigned int 
     }
 }
 
-void Raw<%=name%>::toMpz(mpz_t r, Element &a) {
+void Raw<%=name%>::toMpz(mpz_t r, const Element &a) {
     Element tmp;
     <%=name%>_rawFromMontgomery(tmp.v, a.v);
     mpz_import(r, <%=name%>_N64, -1, 8, -1, 0, (const void *)tmp.v);
 }
 
-void Raw<%=name%>::fromMpz(Element &r, mpz_t a) {
+void Raw<%=name%>::fromMpz(Element &r, const mpz_t a) {
     for (int i=0; i<<%=name%>_N64; i++) r.v[i] = 0;
     mpz_export((void *)(r.v), NULL, -1, 8, -1, 0, a);
     <%=name%>_rawToMontgomery(r.v, r.v);

--- a/src/fr.hpp.ejs
+++ b/src/fr.hpp.ejs
@@ -50,18 +50,18 @@ extern "C" void <%=name%>_toMontgomery(P<%=name%>Element r, P<%=name%>Element a)
 extern "C" int <%=name%>_isTrue(P<%=name%>Element pE);
 extern "C" int <%=name%>_toInt(P<%=name%>Element pE);
 
-extern "C" void <%=name%>_rawCopy(<%=name%>RawElement pRawResult, <%=name%>RawElement pRawA);
+extern "C" void <%=name%>_rawCopy(<%=name%>RawElement pRawResult, const <%=name%>RawElement pRawA);
 extern "C" void <%=name%>_rawSwap(<%=name%>RawElement pRawResult, <%=name%>RawElement pRawA);
-extern "C" void <%=name%>_rawAdd(<%=name%>RawElement pRawResult, <%=name%>RawElement pRawA, <%=name%>RawElement pRawB);
-extern "C" void <%=name%>_rawSub(<%=name%>RawElement pRawResult, <%=name%>RawElement pRawA, <%=name%>RawElement pRawB);
-extern "C" void <%=name%>_rawNeg(<%=name%>RawElement pRawResult, <%=name%>RawElement pRawA);
-extern "C" void <%=name%>_rawMMul(<%=name%>RawElement pRawResult, <%=name%>RawElement pRawA, <%=name%>RawElement pRawB);
-extern "C" void <%=name%>_rawMSquare(<%=name%>RawElement pRawResult, <%=name%>RawElement pRawA);
-extern "C" void <%=name%>_rawMMul1(<%=name%>RawElement pRawResult, <%=name%>RawElement pRawA, uint64_t pRawB);
-extern "C" void <%=name%>_rawToMontgomery(<%=name%>RawElement pRawResult, <%=name%>RawElement pRawA);
-extern "C" void <%=name%>_rawFromMontgomery(<%=name%>RawElement pRawResult, <%=name%>RawElement pRawA);
-extern "C" int <%=name%>_rawIsEq(<%=name%>RawElement pRawA, <%=name%>RawElement pRawB);
-extern "C" int <%=name%>_rawIsZero(<%=name%>RawElement pRawB);
+extern "C" void <%=name%>_rawAdd(<%=name%>RawElement pRawResult, const <%=name%>RawElement pRawA, const <%=name%>RawElement pRawB);
+extern "C" void <%=name%>_rawSub(<%=name%>RawElement pRawResult, const <%=name%>RawElement pRawA, const <%=name%>RawElement pRawB);
+extern "C" void <%=name%>_rawNeg(<%=name%>RawElement pRawResult, const <%=name%>RawElement pRawA);
+extern "C" void <%=name%>_rawMMul(<%=name%>RawElement pRawResult, const <%=name%>RawElement pRawA, const <%=name%>RawElement pRawB);
+extern "C" void <%=name%>_rawMSquare(<%=name%>RawElement pRawResult, const <%=name%>RawElement pRawA);
+extern "C" void <%=name%>_rawMMul1(<%=name%>RawElement pRawResult, const <%=name%>RawElement pRawA, uint64_t pRawB);
+extern "C" void <%=name%>_rawToMontgomery(<%=name%>RawElement pRawResult, const <%=name%>RawElement &pRawA);
+extern "C" void <%=name%>_rawFromMontgomery(<%=name%>RawElement pRawResult, const <%=name%>RawElement &pRawA);
+extern "C" int <%=name%>_rawIsEq(const <%=name%>RawElement pRawA, const <%=name%>RawElement pRawB);
+extern "C" int <%=name%>_rawIsZero(const <%=name%>RawElement pRawB);
 
 extern "C" void <%=name%>_fail();
 
@@ -101,28 +101,28 @@ public:
     Element &one() { return fOne; };
     Element &negOne() { return fNegOne; };
 
-    void fromString(Element &r, std::string n);
-    std::string toString(Element &a, uint32_t radix = 10);
+    void fromString(Element &r, const std::string &n, uint32_t radix = 10);
+    std::string toString(const Element &a, uint32_t radix = 10);
 
-    void inline copy(Element &r, Element &a) { <%=name%>_rawCopy(r.v, a.v); };
+    void inline copy(Element &r, const Element &a) { <%=name%>_rawCopy(r.v, a.v); };
     void inline swap(Element &a, Element &b) { <%=name%>_rawSwap(a.v, b.v); };
-    void inline add(Element &r, Element &a, Element &b) { <%=name%>_rawAdd(r.v, a.v, b.v); };
-    void inline sub(Element &r, Element &a, Element &b) { <%=name%>_rawSub(r.v, a.v, b.v); };
-    void inline mul(Element &r, Element &a, Element &b) { <%=name%>_rawMMul(r.v, a.v, b.v); };
-    void inline mul1(Element &r, Element &a, uint64_t b) { <%=name%>_rawMMul1(r.v, a.v, b); };
-    void inline neg(Element &r, Element &a) { <%=name%>_rawNeg(r.v, a.v); };
-    void inline square(Element &r, Element &a) { <%=name%>_rawMSquare(r.v, a.v); };
-    void inv(Element &r, Element &a);
-    void div(Element &r, Element &a, Element &b);
-    void exp(Element &r, Element &base, uint8_t* scalar, unsigned int scalarSize);
+    void inline add(Element &r, const Element &a, const Element &b) { <%=name%>_rawAdd(r.v, a.v, b.v); };
+    void inline sub(Element &r, const Element &a, const Element &b) { <%=name%>_rawSub(r.v, a.v, b.v); };
+    void inline mul(Element &r, const Element &a, const Element &b) { <%=name%>_rawMMul(r.v, a.v, b.v); };
+    void inline mul1(Element &r, const Element &a, uint64_t b) { <%=name%>_rawMMul1(r.v, a.v, b); };
+    void inline neg(Element &r, const Element &a) { <%=name%>_rawNeg(r.v, a.v); };
+    void inline square(Element &r, const Element &a) { <%=name%>_rawMSquare(r.v, a.v); };
+    void inv(Element &r, const Element &a);
+    void div(Element &r, const Element &a, const Element &b);
+    void exp(Element &r, const Element &base, uint8_t* scalar, unsigned int scalarSize);
 
-    void inline toMontgomery(Element &r, Element &a) { <%=name%>_rawToMontgomery(r.v, a.v); };
-    void inline fromMontgomery(Element &r, Element &a) { <%=name%>_rawFromMontgomery(r.v, a.v); };
-    int inline eq(Element &a, Element &b) { return <%=name%>_rawIsEq(a.v, b.v); };
-    int inline isZero(Element &a) { return <%=name%>_rawIsZero(a.v); };
+    void inline toMontgomery(Element &r, const Element &a) { <%=name%>_rawToMontgomery(r.v, a.v); };
+    void inline fromMontgomery(Element &r, const Element &a) { <%=name%>_rawFromMontgomery(r.v, a.v); };
+    int inline eq(const Element &a, const Element &b) { return <%=name%>_rawIsEq(a.v, b.v); };
+    int inline isZero(const Element &a) { return <%=name%>_rawIsZero(a.v); };
 
-    void toMpz(mpz_t r, Element &a);
-    void fromMpz(Element &a, mpz_t r);
+    void toMpz(mpz_t r, const Element &a);
+    void fromMpz(Element &a, const mpz_t r);
 
     void fromUI(Element &r, unsigned long int v);
 


### PR DESCRIPTION
Add radix argument to fromString() method and use const in constant arguments.
Tested within Hermez prover.