### PR TITLE
remove an unused variable that produces a warning during compilation

### DIFF
--- a/c/multiexp.cpp
+++ b/c/multiexp.cpp
@@ -72,7 +72,6 @@ void ParallelMultiexp<Curve>::reduce(typename Curve::Point &res, uint32_t nBits)
     PaddedPoint *sall = new PaddedPoint[nThreads];
     memset(sall, 0, sizeof(PaddedPoint)*nThreads);
 
-    typename Curve::Point p;
     #pragma omp parallel for
     for (uint32_t i = 1; i<ndiv2; i++) {
         int idThread = omp_get_thread_num();


### PR DESCRIPTION
when all the warnings are full active on compilation, an unused variable warning appears. 