### PR TITLE
Fixing Rpr BE, modifying mpz_export call

### DIFF
--- a/src/fr.cpp.ejs
+++ b/src/fr.cpp.ejs
@@ -297,7 +297,7 @@ int Raw<%=name%>::toRprBE(const Element &element, uint8_t *data, int bytes)
   
     toMpz(r, element);
     
-    mpz_export(data, NULL, 1, 8, 1, 0, r);
+    mpz_export(data, NULL, 1, bytes, 1, 0, r);
   
     return <%=name%>_N64 * 8;
 }


### PR DESCRIPTION
This PR modifies toRprBE so that the size sent to `mpz_export` is the number of bytes specified in the function parameter